### PR TITLE
Fix missing charset meta tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,1 +1,11 @@
-<!DOCTYPE html><html><head><link rel="stylesheet" href="/main.css"></head><body><h1>404</h1><h3>Safak atti, baba kacti.</h3></body></html>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="/main.css">
+</head>
+<body>
+  <h1>404</h1>
+  <h3>Safak atti, baba kacti.</h3>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <meta charset="UTF-8">
   <title>Emre Çamaşuvi</title>
   <style>body{font-family:"Helvetica";text-align:center;padding:50px 20px 0;background:#f4f4f7;color:#444;margin:0;}h1{font-size:65px;line-height:1.2em;border-bottom:#ccc solid 1px;padding:20px 0;}h3{font-weight:300;}.tdn{text-decoration: none}.ml8{margin-left: 8px}</style>
   <script async src="//www.googletagmanager.com/gtag/js?id=UA-28452338-1"></script>


### PR DESCRIPTION
## Summary
- add UTF-8 meta tag to `index.html`
- format `404.html` and add UTF-8 meta tag

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684a86c1709c83289210344308020610